### PR TITLE
Mbed OS 5.15.8, updated sensor drivers & config

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Anjay-mbedos-client
-Copyright 2020-2021 AVSystem
+Copyright 2020-2022 AVSystem
 
 This product includes software developed at AVSystem (www.avsystem.com).
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 
 # Anjay-mbedos-client [<img align="right" height="50px" src="https://avsystem.github.io/Anjay-doc/_images/avsystem_logo.png">](http://www.avsystem.com/)
 
-## Supported hardware and overview
+## Supported hardware
 
 This example project mainly targets the STM32L496AG-DISCOVERY development kit
-[P-L496G-CELL02](https://www.st.com/en/evaluation-tools/p-l496g-cell02.html)
-along with the **optional**
-[X-NUCLEO-IKS02A1](https://www.st.com/en/ecosystems/x-nucleo-iks02a1.html)
-sensor board.
+[P-L496G-CELL02](https://www.st.com/en/evaluation-tools/p-l496g-cell02.html).
 
 However, the code should run with basic functionality on any [officially supported board by Mbed OS](https://os.mbed.com/platforms), having at least 512K flash and 32K of memory and additional SPI
 chip for configuration persistence, with the exception that the network setup will need to be
 implemented (see NetworkService class in main.cpp).
 
-It uses [mbed OS](https://os.mbed.com/mbed-os/) as the base operating system.
+### Sensor board X-NUCLEO-IKS01A2
+
+The application also supports **optional** [X-NUCLEO-IKS01A2](https://www.st.com/en/ecosystems/x-nucleo-iks01a2.html) sensor board. This board can be attaached on top of most STM32 boards. You can enable it via configuration `"SENSORS_IKS01A2=1"` in [`mbed_app.json`](https://github.com/AVSystem/Anjay-mbedos-client/blob/master/mbed_app.json#L3).
+
+## Overview
+
+Application uses [mbed OS](https://os.mbed.com/mbed-os/) as the base operating system.
 
 The following LwM2M Objects are supported in this application:
 
@@ -21,7 +24,10 @@ The following LwM2M Objects are supported in this application:
 - Server (/1),
 - Access Control (/2),
 - Device (/3),
-- Connectivity Monitoring (/4),
+- Connectivity Monitoring (/4).
+
+Following objects are optional depending on HW choice:
+
 - Humidity (/3304),
 - Accelerometer (/3313),
 - Magnetometer (/3314),

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ However, the code should run with basic functionality on any [officially support
 chip for configuration persistence, with the exception that the network setup will need to be
 implemented (see NetworkService class in main.cpp).
 
-It uses [mbed OS](https://www.mbed.com/en/platform/mbed-os/) as the base
-operating system.
+It uses [mbed OS](https://os.mbed.com/mbed-os/) as the base operating system.
 
 The following LwM2M Objects are supported in this application:
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,15 @@
 
 This example project mainly targets the STM32L496AG-DISCOVERY development kit
 [P-L496G-CELL02](https://www.st.com/en/evaluation-tools/p-l496g-cell02.html)
-along with the optional
+along with the **optional**
 [X-NUCLEO-IKS02A1](https://www.st.com/en/ecosystems/x-nucleo-iks02a1.html)
 sensor board.
 
-However, the code should run with basic functionality on any officially supported board by mbedOS:
-https://os.mbed.com/platforms, having at least 512K flash and 32K of memory and additional SPI
+However, the code should run with basic functionality on any [officially supported board by Mbed OS](https://os.mbed.com/platforms), having at least 512K flash and 32K of memory and additional SPI
 chip for configuration persistence, with the exception that the network setup will need to be
 implemented (see NetworkService class in main.cpp).
 
-It uses [mbedOS](https://www.mbed.com/en/platform/mbed-os/) as the base
+It uses [mbed OS](https://www.mbed.com/en/platform/mbed-os/) as the base
 operating system.
 
 The following LwM2M Objects are supported in this application:
@@ -37,7 +36,7 @@ The following LwM2M Objects are supported in this application:
 1. Download and install [Mbed Studio](https://os.mbed.com/studio/)
 2. Start Mbed Studio, click File -> Open Workspace and pick the folder with cloned repository.
 3. In the Libraries view, and then on `(!)` button, and then Fix all, to check out all dependencies (it may take a while).
-4. You can now compile&flash project through UI.
+4. You can now compile and flash project through UI.
 
 NOTE: if you're using a built-in serial monitor, please make sure to use `115200` as a baud rate.
 

--- a/X_NUCLEO_IKS01A2.lib
+++ b/X_NUCLEO_IKS01A2.lib
@@ -1,1 +1,1 @@
-https://developer.mbed.org/teams/ST/code/X_NUCLEO_IKS01A2/#7ced1e5f49dc
+https://developer.mbed.org/teams/ST/code/X_NUCLEO_IKS01A2/#8e441a6884cb

--- a/accelerometer.cpp
+++ b/accelerometer.cpp
@@ -22,6 +22,9 @@
  *
  * This IPSO object can be used to represent a 1-3 axis accelerometer.
  */
+
+#if (SENSORS_IKS01A2 == 1)
+
 #include <algorithm>
 #include <assert.h>
 #include <stdbool.h>
@@ -31,15 +34,14 @@
 #include <avsystem/commons/avs_list_cxx.hpp>
 #include <avsystem/commons/avs_log.h>
 
-#ifdef TARGET_DISCO_L496AG
 
-#    include <XNucleoIKS01A2.h>
+#include <XNucleoIKS01A2.h>
 
-#    include "accelerometer.h"
+#include "accelerometer.h"
 
-#    define ACCELEROMETER_OBJ_LOG(...) avs_log(accelerometer_obj, __VA_ARGS__)
+#define ACCELEROMETER_OBJ_LOG(...) avs_log(accelerometer_obj, __VA_ARGS__)
 
-#    define SENSOR_ID LSM303AGR_ACC_WHO_AM_I
+#define SENSOR_ID LSM303AGR_ACC_WHO_AM_I
 
 using namespace std;
 
@@ -253,4 +255,4 @@ void accelerometer_object_update(anjay_t *anjay) {
     }
 }
 
-#endif // TARGET_DISCO_L496AG
+#endif // SENSORS_IKS01A2

--- a/accelerometer.h
+++ b/accelerometer.h
@@ -29,13 +29,14 @@ void accelerometer_object_update(anjay_t *anjay);
 
 #else // Define dummy functions, compiler optimizes out
 
-int accelerometer_object_install(anjay_t *anjay) {
+static inline int accelerometer_object_install(anjay_t *anjay) {
     return 0;
 }
-void accelerometer_object_uninstall(anjay_t *anjay) {
+
+static inline void accelerometer_object_uninstall(anjay_t *anjay) {
 }
 
-void accelerometer_object_update(anjay_t *anjay) {
+static inline void accelerometer_object_update(anjay_t *anjay) {
 }
 
 #endif // SENSORS_IKS01A2

--- a/accelerometer.h
+++ b/accelerometer.h
@@ -19,7 +19,7 @@
 
 #include <anjay/anjay.h>
 
-#ifdef TARGET_DISCO_L496AG
+#if (SENSORS_IKS01A2 == 1)
 
 int accelerometer_object_install(anjay_t *anjay);
 
@@ -27,6 +27,17 @@ void accelerometer_object_uninstall(anjay_t *anjay);
 
 void accelerometer_object_update(anjay_t *anjay);
 
-#endif // TARGET_DISCO_L496AG
+#else // Define dummy functions, compiler optimizes out
+
+int accelerometer_object_install(anjay_t *anjay) {
+    return 0;
+}
+void accelerometer_object_uninstall(anjay_t *anjay) {
+}
+
+void accelerometer_object_update(anjay_t *anjay) {
+}
+
+#endif // SENSORS_IKS01A2
 
 #endif // ACCELEROMETER_OBJECT_H

--- a/barometer.cpp
+++ b/barometer.cpp
@@ -26,6 +26,8 @@
  * can be measured by the barometer sensor. An example measurement unit
  * is kPa (ucum:kPa).
  */
+#if (SENSORS_IKS01A2 == 1)
+
 #include <assert.h>
 #include <stdbool.h>
 
@@ -35,15 +37,13 @@
 #include <avsystem/commons/avs_log.h>
 #include <avsystem/commons/avs_memory.h>
 
-#ifdef TARGET_DISCO_L496AG
+#include <XNucleoIKS01A2.h>
 
-#    include <XNucleoIKS01A2.h>
+#include "barometer.h"
 
-#    include "barometer.h"
+#define BAROMETER_OBJ_LOG(...) avs_log(barometer_obj, __VA_ARGS__)
 
-#    define BAROMETER_OBJ_LOG(...) avs_log(barometer_obj, __VA_ARGS__)
-
-#    define BAROMETER_OID 3315
+#define BAROMETER_OID 3315
 
 /**
  * Min Measured Value: R, Single, Optional
@@ -328,4 +328,4 @@ void barometer_object_update(anjay_t *anjay) {
     }
 }
 
-#endif // TARGET_DISCO_L496AG
+#endif // SENSORS_IKS01A2

--- a/barometer.h
+++ b/barometer.h
@@ -19,14 +19,23 @@
 
 #include <anjay/anjay.h>
 
-#ifdef TARGET_DISCO_L496AG
+#if (SENSORS_IKS01A2 == 1)
 
 int barometer_object_install(anjay_t *anjay);
-
 void barometer_object_uninstall(anjay_t *anjay);
-
 void barometer_object_update(anjay_t *anjay);
 
-#endif // TARGET_DISCO_L496AG
+#else // Dummy functions if sensor not present
 
+int barometer_object_install(anjay_t *anjay) {
+    return 0;
+}
+
+void barometer_object_uninstall(anjay_t *anjay) {
+}
+
+void barometer_object_update(anjay_t *anjay) {
+}
+
+#endif // SENSORS_IKS01A2
 #endif // BAROMETER_OBJECT_H

--- a/barometer.h
+++ b/barometer.h
@@ -27,14 +27,14 @@ void barometer_object_update(anjay_t *anjay);
 
 #else // Dummy functions if sensor not present
 
-int barometer_object_install(anjay_t *anjay) {
+static inline int barometer_object_install(anjay_t *anjay) {
     return 0;
 }
 
-void barometer_object_uninstall(anjay_t *anjay) {
+static inline void barometer_object_uninstall(anjay_t *anjay) {
 }
 
-void barometer_object_update(anjay_t *anjay) {
+static inline void barometer_object_update(anjay_t *anjay) {
 }
 
 #endif // SENSORS_IKS01A2

--- a/humidity.cpp
+++ b/humidity.cpp
@@ -26,6 +26,9 @@
  * be measured by the humidity sensor. An example measurement unit is
  * relative humidity as a percentage (ucum:%).
  */
+
+#if (SENSORS_IKS01A2 == 1)
+
 #include <assert.h>
 #include <stdbool.h>
 
@@ -37,15 +40,14 @@
 
 #include <mbed.h>
 
-#ifdef TARGET_DISCO_L496AG
 
-#    include <XNucleoIKS01A2.h>
+#include <XNucleoIKS01A2.h>
 
-#    include "humidity.h"
+#include "humidity.h"
 
-#    define HUMIDITY_OBJ_LOG(...) avs_log(humidity_obj, __VA_ARGS__)
+#define HUMIDITY_OBJ_LOG(...) avs_log(humidity_obj, __VA_ARGS__)
 
-#    define SENSOR_ID 0xBC
+#define SENSOR_ID 0xBC
 
 /**
  * Min Measured Value: R, Single, Optional
@@ -331,4 +333,4 @@ void humidity_object_update(anjay_t *anjay) {
     }
 }
 
-#endif // TARGET_DISCO_L496AG
+#endif // SENSORS_IKS01A2

--- a/humidity.h
+++ b/humidity.h
@@ -19,18 +19,26 @@
 
 #include <anjay/anjay.h>
 
-#ifdef TARGET_DISCO_L496AG
+#if (SENSORS_IKS01A2 == 1)
 
-#    define HUMIDITY_OID 3304
-
-#    define HUMIDITY_RID_SENSOR_VALUE 5700
+#define HUMIDITY_OID 3304
+#define HUMIDITY_RID_SENSOR_VALUE 5700
 
 int humidity_object_install(anjay_t *anjay);
-
 void humidity_object_uninstall(anjay_t *anjay);
-
 void humidity_object_update(anjay_t *anjay);
 
-#endif // TARGET_DISCO_L496AG
+#else // No sensor board present, define dummy functions
 
+int humidity_object_install(anjay_t *anjay) {
+    return 0;
+}
+
+void humidity_object_uninstall(anjay_t *anjay) {
+}
+
+void humidity_object_update(anjay_t *anjay) {
+}
+
+#endif // SENSORS_IKS01A2
 #endif // HUMIDITY_OBJECT_H

--- a/humidity.h
+++ b/humidity.h
@@ -30,14 +30,14 @@ void humidity_object_update(anjay_t *anjay);
 
 #else // No sensor board present, define dummy functions
 
-int humidity_object_install(anjay_t *anjay) {
+static inline int humidity_object_install(anjay_t *anjay) {
     return 0;
 }
 
-void humidity_object_uninstall(anjay_t *anjay) {
+static inline void humidity_object_uninstall(anjay_t *anjay) {
 }
 
-void humidity_object_update(anjay_t *anjay) {
+static inline void humidity_object_update(anjay_t *anjay) {
 }
 
 #endif // SENSORS_IKS01A2

--- a/joystick.h
+++ b/joystick.h
@@ -29,14 +29,14 @@ void joystick_object_update(anjay_t *anjay);
 
 #else // No joystick present - define "dummy" functions that compiler optimizes away
 
-int joystick_object_install(anjay_t *anjay) {
+static inline int joystick_object_install(anjay_t *anjay) {
     return 0;
 }
 
-void joystick_object_uninstall(anjay_t *anjay) {
+static inline void joystick_object_uninstall(anjay_t *anjay) {
 }
 
-void joystick_object_update(anjay_t *anjay) {
+static inline void joystick_object_update(anjay_t *anjay) {
 }
 
 #endif // TARGET_DISCO_L496AG

--- a/joystick.h
+++ b/joystick.h
@@ -27,6 +27,18 @@ void joystick_object_uninstall(anjay_t *anjay);
 
 void joystick_object_update(anjay_t *anjay);
 
+#else // No joystick present - define "dummy" functions that compiler optimizes away
+
+int joystick_object_install(anjay_t *anjay) {
+    return 0;
+}
+
+void joystick_object_uninstall(anjay_t *anjay) {
+}
+
+void joystick_object_update(anjay_t *anjay) {
+}
+
 #endif // TARGET_DISCO_L496AG
 
 #endif // JOYSTICK_OBJECT_H

--- a/magnetometer.cpp
+++ b/magnetometer.cpp
@@ -23,6 +23,8 @@
  * This IPSO object can be used to represent a 1-3 axis magnetometer with
  * optional compass direction.
  */
+#if (SENSORS_IKS01A2 == 1)
+
 #include <algorithm>
 #include <assert.h>
 #include <stdbool.h>
@@ -34,15 +36,13 @@
 
 #include <mbed.h>
 
-#ifdef TARGET_DISCO_L496AG
+#include <XNucleoIKS01A2.h>
 
-#    include <XNucleoIKS01A2.h>
+#include "magnetometer.h"
 
-#    include "magnetometer.h"
+#define MAGNETOMETER_OBJ_LOG(...) avs_log(magnetometer_obj, __VA_ARGS__)
 
-#    define MAGNETOMETER_OBJ_LOG(...) avs_log(magnetometer_obj, __VA_ARGS__)
-
-#    define SENSOR_ID LSM303AGR_MAG_WHO_AM_I
+#define SENSOR_ID LSM303AGR_MAG_WHO_AM_I
 
 using namespace std;
 
@@ -255,4 +255,4 @@ void magnetometer_object_update(anjay_t *anjay) {
     }
 }
 
-#endif // TARGET_DISCO_L496AG
+#endif // SENSORS_IKS01A2

--- a/magnetometer.h
+++ b/magnetometer.h
@@ -27,14 +27,14 @@ void magnetometer_object_update(anjay_t *anjay);
 
 #else  // Dummy functions in case sensor not present
 
-int magnetometer_object_install(anjay_t *anjay) {
+static inline int magnetometer_object_install(anjay_t *anjay) {
     return 0;
 }
 
-void magnetometer_object_uninstall(anjay_t *anjay) {
+static inline void magnetometer_object_uninstall(anjay_t *anjay) {
 }
 
-void magnetometer_object_update(anjay_t *anjay) {
+static inline void magnetometer_object_update(anjay_t *anjay) {
 }
 
 #endif // SENSORS_IKS01A2

--- a/magnetometer.h
+++ b/magnetometer.h
@@ -19,14 +19,23 @@
 
 #include <anjay/anjay.h>
 
-#ifdef TARGET_DISCO_L496AG
+#if (SENSORS_IKS01A2 == 1)
 
 int magnetometer_object_install(anjay_t *anjay);
-
 void magnetometer_object_uninstall(anjay_t *anjay);
-
 void magnetometer_object_update(anjay_t *anjay);
 
-#endif // TARGET_DISCO_L496AG
+#else  // Dummy functions in case sensor not present
 
+int magnetometer_object_install(anjay_t *anjay) {
+    return 0;
+}
+
+void magnetometer_object_uninstall(anjay_t *anjay) {
+}
+
+void magnetometer_object_update(anjay_t *anjay) {
+}
+
+#endif // SENSORS_IKS01A2
 #endif // MAGNETOMETER_OBJECT_H

--- a/main.cpp
+++ b/main.cpp
@@ -416,6 +416,7 @@ public:
 
         NetworkInterface *netif = NetworkInterface::get_default_instance();
         if (!netif) {
+            printf("ERROR - can't get default network instance!\n");
             return -1;
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -35,13 +35,12 @@
 #include <mbed_trace.h>
 #include <memory>
 
-#ifdef TARGET_DISCO_L496AG
-#include "accelerometer.h"
+#include "joystick.h"       // gets activated with TARGET_DISCO_L496AG
+
+#include "accelerometer.h"  // Gets activated with SENSORS_IKS01A2=0
 #include "barometer.h"
 #include "humidity.h"
-#include "joystick.h"
 #include "magnetometer.h"
-#endif // TARGET_DISCO_L496AG
 
 #include "default_config.h"
 
@@ -250,12 +249,11 @@ void lwm2m_serve() {
 
         if (setup_security_object() || setup_server_object()
             || device_object_install(anjay)
-#ifdef TARGET_DISCO_L496AG
-            || joystick_object_install(anjay) || humidity_object_install(anjay)
+            || joystick_object_install(anjay) 
+            || humidity_object_install(anjay)
             || barometer_object_install(anjay)
             || magnetometer_object_install(anjay)
             || accelerometer_object_install(anjay)
-#endif // TARGET_DISCO_L496AG
         ) {
             avs_log(lwm2m, ERROR, "cannot register data model objects");
             goto finish;
@@ -278,13 +276,11 @@ void lwm2m_serve() {
         if (anjay) {
             conn_monitoring_object_uninstall(anjay);
             device_object_uninstall(anjay);
-#ifdef TARGET_DISCO_L496AG
             joystick_object_uninstall(anjay);
             humidity_object_uninstall(anjay);
             barometer_object_uninstall(anjay);
             magnetometer_object_uninstall(anjay);
             accelerometer_object_uninstall(anjay);
-#endif // TARGET_DISCO_L496AG
             anjay_delete(anjay);
             anjay = NULL;
         }
@@ -299,13 +295,11 @@ void lwm2m_check_for_notifications(void) {
         {
             ScopedLock<Mutex> lock(anjay_mtx);
             device_object_update(anjay);
-#ifdef TARGET_DISCO_L496AG
             humidity_object_update(anjay);
             barometer_object_update(anjay);
             joystick_object_update(anjay);
             magnetometer_object_update(anjay);
             accelerometer_object_update(anjay);
-#endif // TARGET_DISCO_L496AG
         }
         ThisThread::sleep_for(1000);
     }

--- a/main.cpp
+++ b/main.cpp
@@ -411,6 +411,9 @@ public:
      * @returns 0 on success, negative value otherwise.
      */
     int init(Lwm2mConfig &config) {
+        SocketAddress sa;
+        nsapi_error_t err;
+
         NetworkInterface *netif = NetworkInterface::get_default_instance();
         if (!netif) {
             return -1;
@@ -432,6 +435,15 @@ public:
         if (CellularDevice *device = CellularDevice::get_default_instance()) {
             NETWORK = device->open_network();
             NETWORK->set_access_technology(config.modem_config.rat);
+        }
+
+        // Print IP address and MAC address, quite useful in troubleshooting
+        err = netif->get_ip_address(&sa);
+        if (err != NSAPI_ERROR_OK) {
+            printf("get_ip_address() - failed, status %d\n", err);
+        } else {
+            printf("IP: %s\n", (sa.get_ip_address() ? sa.get_ip_address() : "None"));
+            printf("MAC address: %s\n", (netif->get_mac_address() ? netif->get_mac_address() : "None"));
         }
 
         iface_ = netif;

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b005bf21337e6ffe5393671b92066c3b09c5204b
+https://github.com/ARMmbed/mbed-os/#8e3d10054c175741c04e3595822292e56ebab6ef

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,5 +1,6 @@
 {
   "macros": [
+    "SENSORS_IKS01A2=0",
     "__STDC_FORMAT_MACROS",
     "MBED_CPU_STATS_ENABLED=1",
     "MBED_HEAP_STATS_ENABLED=1",


### PR DESCRIPTION
* Add network IP address & MAC printing.
* Update Mbed OS to known release version from 5.15-branch.
* Update sensor driver code to latest version.
* Change sensor abstraction level to be it's own. 
    * It does not depend on the board target - you can attach the sensor board to almost any STM32 devkit and it will work.
    *Tidy up the way the configurations are done - centralize them to the header to minimize ifdefs.

With the default option of `SENSOR_IKS01A2=0` they get left out completely. Compiler knows how to optimize them out.

```
| Module                      |           .text |       .data |          .bss |
|-----------------------------|-----------------|-------------|---------------|
| [fill]                      |       648(+648) |     14(+14) |       92(+92) |
| [lib]/c.a                   |   49008(+49008) | 2474(+2474) |       89(+89) |
| [lib]/gcc.a                 |     7896(+7896) |       0(+0) |         0(+0) |
| [lib]/m.a                   |     1032(+1032) |       1(+1) |         0(+0) |
| [lib]/misc                  |       180(+180) |       4(+4) |       28(+28) |
| [lib]/nosys.a               |         32(+32) |       0(+0) |         0(+0) |
| [lib]/stdc++.a              |     5928(+5928) |       8(+8) |       44(+44) |
| anjay-mbedos/Anjay          | 124058(+124058) |       0(+0) |         0(+0) |
| anjay-mbedos/avs_commons    |   26844(+26844) |     12(+12) |       16(+16) |
| anjay-mbedos/src            |   12606(+12606) |       4(+4) |     158(+158) |
| conn_monitoring_object.o    |       904(+904) |       0(+0) |       92(+92) |
| device_config_serial_menu.o |     5604(+5604) |       0(+0) |         0(+0) |
| device_object.o             |     1192(+1192) |       0(+0) |       92(+92) |
| main.o                      |     2488(+2488) |       0(+0) |     828(+828) |
| mbed-os/components          |       282(+282) |       0(+0) |         0(+0) |
| mbed-os/drivers             |       720(+720) |       0(+0) |         0(+0) |
| mbed-os/events              |     1454(+1454) |       0(+0) |   3108(+3108) |
| mbed-os/features            | 166262(+166262) |   234(+234) | 23641(+23641) |
| mbed-os/hal                 |     2682(+2682) |       8(+8) |     247(+247) |
| mbed-os/platform            |     5704(+5704) |   276(+276) |     462(+462) |
| mbed-os/rtos                |   11252(+11252) |   168(+168) |   5981(+5981) |
| mbed-os/targets             |   12914(+12914) |       5(+5) |     730(+730) |
| serial_menu.o               |       494(+494) |       0(+0) |         0(+0) |
| Subtotals                   | 440184(+440184) | 3208(+3208) | 35608(+35608) |
Total Static RAM memory (data + bss): 38816(+38816) bytes
Total Flash memory (text + data): 443392(+443392) bytes

Update Image: ./BUILD/NUCLEO_F429ZI/GCC_ARM/Anjay-mbedos-client_update.bin
Image: ./BUILD/NUCLEO_F429ZI/GCC_ARM/Anjay-mbedos-client.bin

```
