### PR TITLE
mbed_app.json - do not default * to cellular

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -17,7 +17,7 @@
       "platform.stdio-baud-rate": 115200,
       "platform.stdio-convert-newlines": 1,
       "target.OUTPUT_EXT": "bin",
-      "target.app_offset": "0x10000",
+      "target.app_offset": "0x10000"
     },
     "DISCO_L496AG": {
       "stmod_cellular.provide-default": "true",

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -18,7 +18,6 @@
       "platform.stdio-convert-newlines": 1,
       "target.OUTPUT_EXT": "bin",
       "target.app_offset": "0x10000",
-      "target.network-default-interface-type": "CELLULAR"
     },
     "DISCO_L496AG": {
       "stmod_cellular.provide-default": "true",


### PR DESCRIPTION
Cellular should be really a target specific thing and/or overrride.
The default mbed_app.json should really allow the default machine
config to give what it has, you then override per target.

F429ZI for example can't be compiled with this `mbed_app.json` (without modifying it).
Nor any other target w/o cellular either (read: bulk of all targets).
Targets that have a network interface out-of-box in Mbed OS have
also the default network interface defined, as is.