### PR TITLE
Simplify target name handling

### DIFF
--- a/device_object.cpp
+++ b/device_object.cpp
@@ -181,14 +181,7 @@ static const char *device_manufacturer(void) {
 }
 
 static const char *model_number(void) {
-#ifdef TARGET_DISCO_L496AG
-    return "STM32L496G-DISCO";
-#elif TARGET_NRF52840_DK
-    return "nRF52840 DK";
-#else
-#    warning "Add model number"
-    return "Unknown";
-#endif
+    return MBED_STRINGIFY(TARGET_NAME);
 }
 
 static int resource_read(anjay_t *anjay,


### PR DESCRIPTION
There is already a mechanism for this, no need to #ifdef every target.
Just stringify TARGET_NAME and there you have it.

Please review @kFYatek 
